### PR TITLE
Upgrade Go toolchain to 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20.x'
+          go-version: '1.24.x'
       - name: Cache Go build
         uses: actions/cache@v4
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.20.8
+golang 1.24.5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - `make rpm`: Runs `buildrpm.sh` to assemble RPM outputs inside `rpm/` and `rpmbuild/`.
 - `go run .` / `./goqos set ...`: Exercise the CLI locally; combine with `view` and `clear` to verify end-to-end flows.
 - `go mod tidy`: Refreshes `go.mod`/`go.sum` after adding or removing dependencies.
+Use Go 1.24.x (managed via `.tool-versions` or `actions/setup-go`) to match the CI environment.
 
 ## Coding Style & Naming Conventions
 Always run `go fmt ./...` (or `gofmt`) before committing. Exported identifiers use PascalCase, internal identifiers use camelCase, and wrap errors with `fmt.Errorf("...: %w", err)` when propagating to preserve context. Shell scripts and spec files should follow POSIX syntax with consistent two-space indentation for YAML fragments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - `make rpm`: Runs `buildrpm.sh` to assemble RPM outputs inside `rpm/` and `rpmbuild/`.
 - `go run .` / `./goqos set ...`: Exercise the CLI locally; combine with `view` and `clear` to verify end-to-end flows.
 - `go mod tidy`: Refreshes `go.mod`/`go.sum` after adding or removing dependencies.
-Use Go 1.24.x (managed via `.tool-versions` or `actions/setup-go`) to match the CI environment.
+- Use Go 1.24.x (managed via `.tool-versions` or `actions/setup-go`) to match the CI environment.
 
 ## Coding Style & Naming Conventions
 Always run `go fmt ./...` (or `gofmt`) before committing. Exported identifiers use PascalCase, internal identifiers use camelCase, and wrap errors with `fmt.Errorf("...: %w", err)` when propagating to preserve context. Shell scripts and spec files should follow POSIX syntax with consistent two-space indentation for YAML fragments.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/yuokada/goqos
 
-go 1.20
+go 1.24

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -231,7 +230,7 @@ func view(ip net.IP) {
 			if err != nil && !os.IsExist(err) {
 				continue
 			}
-			contents, err := ioutil.ReadFile(config_file)
+			contents, err := os.ReadFile(config_file)
 			if err != nil {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func view(ip net.IP) {
 		}
 	}
 	if len(outputs) != 0 {
-		fmt.Printf(strings.Join(outputs, ""))
+		fmt.Print(strings.Join(outputs, ""))
 	} else {
 		fmt.Println("nothing")
 	}


### PR DESCRIPTION
This pull request upgrades the project to use Go 1.24.x throughout the codebase and CI, adds documentation to reflect this requirement, and makes a small code improvement in the output logic of the `view` function. The most important changes are grouped below:

Go version upgrade:

* Updated the Go version in `.tool-versions` to `1.24.5` to ensure local development uses the correct version.
* Changed the Go version in the GitHub Actions CI workflow (`.github/workflows/ci.yml`) from `1.20.x` to `1.24.x` for consistency with local development.
* Updated the Go version declaration in `go.mod` from `1.20` to `1.24`.

Documentation update:

* Added a note to `AGENTS.md` instructing developers to use Go 1.24.x, matching the CI environment.

Code improvement:

* Changed `fmt.Printf(strings.Join(outputs, ""))` to `fmt.Print(strings.Join(outputs, ""))` in the `view` function in `main.go` for clarity and correctness.